### PR TITLE
fix PriorityQueue and PriorityBlockingQueue HashCode bug

### DIFF
--- a/priorityblockingqueue.go
+++ b/priorityblockingqueue.go
@@ -13,6 +13,8 @@ type PriorityBlockingQueue struct {
 	lock          sync.Mutex
 	priorityQueue PriorityQueue
 	cond          *sync.Cond
+
+	hashCode int
 }
 
 func NewPriorityBlockingQueue() *PriorityBlockingQueue {
@@ -192,7 +194,13 @@ func (this *PriorityBlockingQueue) Equals(i interface{}) bool {
 }
 
 func (this *PriorityBlockingQueue) HashCode() int {
-	return int(uintptr(unsafe.Pointer(this)))
+	hashCode := this.hashCode
+	if hashCode != 0 {
+		return hashCode
+	}
+	hashCode = int(uintptr(unsafe.Pointer(this)))
+	this.hashCode = hashCode
+	return hashCode
 }
 
 func (this *PriorityBlockingQueue) Offer(i interface{}) bool {

--- a/priorityqueue.go
+++ b/priorityqueue.go
@@ -17,6 +17,8 @@ type priorityData struct {
 
 type PriorityQueue struct {
 	data priorityData
+
+	hashCode int
 }
 
 type priorityQueueIter struct {
@@ -246,7 +248,13 @@ func (this *PriorityQueue) Equals(i interface{}) bool {
 }
 
 func (this *PriorityQueue) HashCode() int {
-	return int(uintptr(unsafe.Pointer(this)))
+	hashCode := this.hashCode
+	if hashCode != 0 {
+		return hashCode
+	}
+	hashCode = int(uintptr(unsafe.Pointer(this)))
+	this.hashCode = hashCode
+	return hashCode
 }
 
 func (this *PriorityQueue) Offer(i interface{}) bool {


### PR DESCRIPTION
HashCode() should return non-volatile value.

Store object address and restore it when invoking HashCode().